### PR TITLE
Add "Swearwords and Software Engineering" section and cite Strehmel 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@ engineering methodologies.
 ## Internet-Draft
 
 The [Programming Methodology Framework, aka PMF](raw.md.txt), is available in ASCII format. Published as [draft-02](https://www.ietf.org/archive/id/draft-dulaunoy-programming-methodology-framework-02.html).
+
+## Swearwords and Software Engineering
+
+PMF includes a section on the engineering value of treating swearwords and
+other emotionally charged programmer vocabulary as signals. The section cites
+Jan Strehmel's 2023 study, [Is there a Correlation between the Use of
+Swearwords and Code Quality in Open Source Code?](doc/JanThesis.pdf), while
+noting that the reported correlation should not be read as advice to add
+swearwords artificially.

--- a/raw.md
+++ b/raw.md
@@ -106,6 +106,30 @@ the programming aspect, and it serves solely to support the PMF methodology.
 - Provide programmers with the desired requirements.
 - Review whether the software to be delivered matches the requirements.
 
+## Swearwords and Software Engineering
+
+PMF recognises that the vocabulary found in source code, comments, commit
+messages, and adjacent engineering conversations can carry useful information
+about how programmers experience the code they maintain. Strehmel's empirical
+study of open-source C repositories compared projects containing English
+swearwords with projects that did not contain them and reported that the former
+set showed significantly better adherence to coding standards under several
+statistical tests [@?SWEARWORDS-CODE-QUALITY].
+
+This observation is important for PMF because it treats apparently informal
+programmer expression as a signal that can be studied rather than dismissed.
+Swearwords can indicate emotional involvement, frustration with unnecessary
+complexity, or unusually direct feedback about code paths that deserve
+attention. In practical software engineering, such signals can help teams
+identify confusing interfaces, fragile components, and places where programmers
+have invested enough attention to leave candid warnings for future readers.
+
+The correlation MUST NOT be interpreted as a recommendation to add swearwords
+to source code to improve quality. PMF instead recommends that teams preserve
+useful technical context, review emotionally charged comments with empathy, and
+turn the underlying engineering signal into tests, refactoring, documentation,
+or clearer interfaces.
+
 ##  Conventions and Terminology
 
 The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**",
@@ -134,6 +158,14 @@ The authors wish to thank all the programmers who program.
    <title>The Tao of Programming</title>
    <author initials='' surname='James' fullname='Geoffrey James'></author>
    <date></date>
+  </front>
+</reference>
+
+<reference anchor='SWEARWORDS-CODE-QUALITY' target='https://cme.h-its.org/exelixis/pubs/JanThesis.pdf'>
+  <front>
+   <title>Is there a Correlation between the Use of Swearwords and Code Quality in Open Source Code?</title>
+   <author initials='J.' surname='Strehmel' fullname='Jan Strehmel'></author>
+   <date year='2023'></date>
   </front>
 </reference>
 

--- a/raw.md.html
+++ b/raw.md.html
@@ -1313,7 +1313,10 @@ to official engineering or project documents describing one of the most used sof
                 <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="auto internal xref">1.1</a>.  <a href="#name-management-and-pmf-methodol" class="internal xref">Management and PMF methodology</a></p>
 </li>
               <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.2">
-                <p id="section-toc.1-1.1.2.2.1" class="keepWithNext"><a href="#section-1.2" class="auto internal xref">1.2</a>.  <a href="#name-conventions-and-terminology" class="internal xref">Conventions and Terminology</a></p>
+                <p id="section-toc.1-1.1.2.2.1" class="keepWithNext"><a href="#section-1.2" class="auto internal xref">1.2</a>.  <a href="#name-swearwords-and-software-eng" class="internal xref">Swearwords and Software Engineering</a></p>
+</li>
+              <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.1.2.3">
+                <p id="section-toc.1-1.1.2.3.1" class="keepWithNext"><a href="#section-1.3" class="auto internal xref">1.3</a>.  <a href="#name-conventions-and-terminology" class="internal xref">Conventions and Terminology</a></p>
 </li>
             </ul>
 </li>
@@ -1402,14 +1405,24 @@ the programming aspect and solely serves to support the PMF methodology.<a href=
         </ul>
 </section>
 </div>
-<div id="conventions-and-terminology">
+<div id="swearwords-and-software-engineering">
 <section id="section-1.2">
-        <h3 id="name-conventions-and-terminology">
-<a href="#section-1.2" class="section-number selfRef">1.2. </a><a href="#name-conventions-and-terminology" class="section-name selfRef">Conventions and Terminology</a>
+        <h3 id="name-swearwords-and-software-eng">
+<a href="#section-1.2" class="section-number selfRef">1.2. </a><a href="#name-swearwords-and-software-eng" class="section-name selfRef">Swearwords and Software Engineering</a>
         </h3>
-<p id="section-1.2-1">The key words "<span class="bcp14">MUST</span>", "<span class="bcp14">MUST NOT</span>", "<span class="bcp14">REQUIRED</span>", "<span class="bcp14">SHALL</span>", "<span class="bcp14">SHALL NOT</span>",
+<p id="section-1.2-1">PMF recognises that the vocabulary found in source code, comments, commit messages, and adjacent engineering conversations can carry useful information about how programmers experience the code they maintain. Strehmel's empirical study of open-source C repositories compared projects containing English swearwords with projects that did not contain them and reported that the former set showed significantly better adherence to coding standards under several statistical tests <span>[<a href="#SWEARWORDS-CODE-QUALITY" class="cite xref">SWEARWORDS-CODE-QUALITY</a>]</span>.<a href="#section-1.2-1" class="pilcrow">¶</a></p>
+<p id="section-1.2-2">This observation is important for PMF because it treats apparently informal programmer expression as a signal that can be studied rather than dismissed. Swearwords can indicate emotional involvement, frustration with unnecessary complexity, or unusually direct feedback about code paths that deserve attention. In practical software engineering, such signals can help teams identify confusing interfaces, fragile components, and places where programmers have invested enough attention to leave candid warnings for future readers.<a href="#section-1.2-2" class="pilcrow">¶</a></p>
+<p id="section-1.2-3">The correlation <span class="bcp14">MUST NOT</span> be interpreted as a recommendation to add swearwords to source code to improve quality. PMF instead recommends that teams preserve useful technical context, review emotionally charged comments with empathy, and turn the underlying engineering signal into tests, refactoring, documentation, or clearer interfaces.<a href="#section-1.2-3" class="pilcrow">¶</a></p>
+</section>
+</div>
+<div id="conventions-and-terminology">
+<section id="section-1.3">
+        <h3 id="name-conventions-and-terminology">
+<a href="#section-1.3" class="section-number selfRef">1.3. </a><a href="#name-conventions-and-terminology" class="section-name selfRef">Conventions and Terminology</a>
+        </h3>
+<p id="section-1.3-1">The key words "<span class="bcp14">MUST</span>", "<span class="bcp14">MUST NOT</span>", "<span class="bcp14">REQUIRED</span>", "<span class="bcp14">SHALL</span>", "<span class="bcp14">SHALL NOT</span>",
 "<span class="bcp14">SHOULD</span>", "<span class="bcp14">SHOULD NOT</span>", "<span class="bcp14">RECOMMENDED</span>", "<span class="bcp14">MAY</span>", and "<span class="bcp14">OPTIONAL</span>" in this
-document are to be interpreted as described in RFC 2119 <span>[<a href="#RFC2119" class="cite xref">RFC2119</a>]</span>.<a href="#section-1.2-1" class="pilcrow">¶</a></p>
+document are to be interpreted as described in RFC 2119 <span>[<a href="#RFC2119" class="cite xref">RFC2119</a>]</span>.<a href="#section-1.3-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 </section>
@@ -1458,6 +1471,10 @@ includes the act of simplifying or removing code to reduce the attack surface.<a
 <dt id="THE-TAO-OF-PROGRAMMING">[THE-TAO-OF-PROGRAMMING]</dt>
       <dd>
 <span class="refAuthor">James, G.</span>, <span class="refTitle">"The Tao of Programming"</span>, <span>&lt;<a href="http://www.mit.edu/~xela/tao.html">http://www.mit.edu/~xela/tao.html</a>&gt;</span>. </dd>
+<dd class="break"></dd>
+<dt id="SWEARWORDS-CODE-QUALITY">[SWEARWORDS-CODE-QUALITY]</dt>
+      <dd>
+<span class="refAuthor">Strehmel, J.</span>, <span class="refTitle">"Is there a Correlation between the Use of Swearwords and Code Quality in Open Source Code?"</span>, <time datetime="2023" class="refDate">2023</time>, <span>&lt;<a href="https://cme.h-its.org/exelixis/pubs/JanThesis.pdf">https://cme.h-its.org/exelixis/pubs/JanThesis.pdf</a>&gt;</span>. </dd>
 <dd class="break"></dd>
 </dl>
 </section>

--- a/raw.md.txt
+++ b/raw.md.txt
@@ -54,7 +54,9 @@ Copyright Notice
 
 
 Dulaunoy & Iklody       Expires 24 November 2024                [Page 1]
-
+     1.2.  Swearwords and Software Engineering . . . . . . . . . .   3
+     1.3.  Conventions and Terminology . . . . . . . . . . . . . .   3
+
 Internet-Draft   PMF - Programming Methodology Framework        May 2024
 
 
@@ -122,7 +124,38 @@ Internet-Draft   PMF - Programming Methodology Framework        May 2024
         |            |
         |            |
    +----v-----+      |
-   |          |      | it doesn't work
+1.2.  Swearwords and Software Engineering
+
+   PMF recognises that the vocabulary found in source code, comments,
+   commit messages, and adjacent engineering conversations can carry
+   useful information about how programmers experience the code they
+   maintain.  Strehmel's empirical study of open-source C repositories
+   compared projects containing English swearwords with projects that
+   did not contain them and reported that the former set showed
+   significantly better adherence to coding standards under several
+   statistical tests [SWEARWORDS-CODE-QUALITY].
+
+   This observation is important for PMF because it treats apparently
+   informal programmer expression as a signal that can be studied rather
+   than dismissed.  Swearwords can indicate emotional involvement,
+   frustration with unnecessary complexity, or unusually direct feedback
+   about code paths that deserve attention.  In practical software
+   engineering, such signals can help teams identify confusing
+   interfaces, fragile components, and places where programmers have
+   invested enough attention to leave candid warnings for future readers.
+
+   The correlation MUST NOT be interpreted as a recommendation to add
+   swearwords to source code to improve quality.  PMF instead recommends
+   that teams preserve useful technical context, review emotionally
+   charged comments with empathy, and turn the underlying engineering
+   signal into tests, refactoring, documentation, or clearer interfaces.
+
+1.3.  Conventions and Terminology
+   [SWEARWORDS-CODE-QUALITY]
+              Strehmel, J., "Is there a Correlation between the Use of
+              Swearwords and Code Quality in Open Source Code?", 2023,
+              <https://cme.h-its.org/exelixis/pubs/JanThesis.pdf>.
+
    |   code   |      |
    |          |      |
    +----+-----+      |

--- a/raw.md.xml
+++ b/raw.md.xml
@@ -83,6 +83,28 @@ the programming aspect and solely serves to support the PMF methodology.</t>
 </ul>
 </section>
 
+<section anchor="swearwords-and-software-engineering"><name>Swearwords and Software Engineering</name>
+<t>PMF recognises that the vocabulary found in source code, comments, commit
+messages, and adjacent engineering conversations can carry useful information
+about how programmers experience the code they maintain. Strehmel's empirical
+study of open-source C repositories compared projects containing English
+swearwords with projects that did not contain them and reported that the former
+set showed significantly better adherence to coding standards under several
+statistical tests <xref target="SWEARWORDS-CODE-QUALITY"></xref>.</t>
+<t>This observation is important for PMF because it treats apparently informal
+programmer expression as a signal that can be studied rather than dismissed.
+Swearwords can indicate emotional involvement, frustration with unnecessary
+complexity, or unusually direct feedback about code paths that deserve
+attention. In practical software engineering, such signals can help teams
+identify confusing interfaces, fragile components, and places where programmers
+have invested enough attention to leave candid warnings for future readers.</t>
+<t>The correlation <bcp14>MUST NOT</bcp14> be interpreted as a recommendation to add swearwords
+to source code to improve quality. PMF instead recommends that teams preserve
+useful technical context, review emotionally charged comments with empathy, and
+turn the underlying engineering signal into tests, refactoring, documentation,
+or clearer interfaces.</t>
+</section>
+
 <section anchor="conventions-and-terminology"><name>Conventions and Terminology</name>
 <t>The key words &quot;<bcp14>MUST</bcp14>&quot;, &quot;<bcp14>MUST NOT</bcp14>&quot;, &quot;<bcp14>REQUIRED</bcp14>&quot;, &quot;<bcp14>SHALL</bcp14>&quot;, &quot;<bcp14>SHALL NOT</bcp14>&quot;,
 &quot;<bcp14>SHOULD</bcp14>&quot;, &quot;<bcp14>SHOULD NOT</bcp14>&quot;, &quot;<bcp14>RECOMMENDED</bcp14>&quot;, &quot;<bcp14>MAY</bcp14>&quot;, and &quot;<bcp14>OPTIONAL</bcp14>&quot; in this
@@ -119,6 +141,13 @@ includes the act of simplifying or removing code to reduce the attack surface.</
     <title>The Tao of Programming</title>
     <author fullname="Geoffrey James" surname="James"></author>
     <date></date>
+  </front>
+</reference>
+<reference anchor="SWEARWORDS-CODE-QUALITY" target="https://cme.h-its.org/exelixis/pubs/JanThesis.pdf">
+  <front>
+    <title>Is there a Correlation between the Use of Swearwords and Code Quality in Open Source Code?</title>
+    <author fullname="Jan Strehmel" initials="J." surname="Strehmel"></author>
+    <date year="2023"></date>
   </front>
 </reference>
 </references>


### PR DESCRIPTION
### Motivation
- Provide PMF with an explicit discussion of how emotionally charged programmer vocabulary can act as an engineering signal. 
- Surface an empirical reference that studies the correlation between swearword usage and code quality to support analysis in the draft. 

### Description
- Added a new section `Swearwords and Software Engineering` to the draft source (`raw.md`) explaining why swearwords in code/comments can be informative while warning that this is not advice to introduce them. 
- Added an informative reference for Jan Strehmel's 2023 study (`SWEARWORDS-CODE-QUALITY`) and updated generated artifacts (`raw.md.xml`, `raw.md.txt`, `raw.md.html`) and `README.md` to mention the section and local `doc/JanThesis.pdf`. 
- Ensured the XML remains well-formed after edits and updated table-of-contents numbering in the text/HTML outputs. 

### Testing
- Parsed `raw.md.xml` with `xml.etree.ElementTree` and `ET.parse('raw.md.xml')` succeeded. 
- Parsed `raw.md.html` with Python's `HTMLParser` and feeding the file succeeded. 
- Ran `git diff --check` with no issues reported, but `make all` could not complete because the `mmark` executable is not installed in the environment. 
- Attempted to install `xml2rfc` via `pip` but the package retrieval failed in this environment (network/tunnel restriction), so full RFC generation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b479fd88483248ff7e68e047bd9c1)